### PR TITLE
Add collapse/expand all buttons to outline toolbar

### DIFF
--- a/src/components/outlineWindow.ts
+++ b/src/components/outlineWindow.ts
@@ -15,6 +15,8 @@ export default class OutlineWindow {
 	private _containerEl: HTMLDivElement;
 	private _latestHeadings: HeadingCache[] = [];
 	private _toolbarEl!: HTMLDivElement;
+	private _collapseToggleBtn!: HTMLDivElement;
+	private _allCollapsed = false;
 	private _pinned = false;
 
 	constructor(plugin: DynamicOutlinePlugin, outline: Outline) {
@@ -149,6 +151,10 @@ export default class OutlineWindow {
 
 		this._latestHeadings = headings;
 		ulElement.empty();
+
+		this._allCollapsed = false;
+		setIcon(this._collapseToggleBtn, "chevrons-down-up");
+		this._collapseToggleBtn.setAttribute("aria-label", "Collapse all");
 
 		let isCollapsingPossibleGlobally = false;
 		if (!this._plugin.settings.disableHeadingCollapsing) {
@@ -400,19 +406,12 @@ export default class OutlineWindow {
 			cls: "dynamic-outline-toolbar hidden",
 		});
 
-		const collapseAllBtn = this._toolbarEl.createDiv({
+		this._collapseToggleBtn = this._toolbarEl.createDiv({
 			cls: "clickable-icon",
 			attr: { "aria-label": "Collapse all" },
 		});
-		setIcon(collapseAllBtn, "chevrons-down-up");
-		collapseAllBtn.addEventListener("click", () => this._collapseAll());
-
-		const expandAllBtn = this._toolbarEl.createDiv({
-			cls: "clickable-icon",
-			attr: { "aria-label": "Expand all" },
-		});
-		setIcon(expandAllBtn, "chevrons-up-down");
-		expandAllBtn.addEventListener("click", () => this._expandAll());
+		setIcon(this._collapseToggleBtn, "chevrons-down-up");
+		this._collapseToggleBtn.addEventListener("click", () => this._toggleCollapseAll());
 
 		mainElement.appendChild(this._toolbarEl);
 
@@ -428,6 +427,20 @@ export default class OutlineWindow {
 		mainElement.appendChild(contentElement);
 
 		return mainElement;
+	}
+
+	private _toggleCollapseAll(): void {
+		if (this._allCollapsed) {
+			this._expandAll();
+			this._allCollapsed = false;
+			setIcon(this._collapseToggleBtn, "chevrons-down-up");
+			this._collapseToggleBtn.setAttribute("aria-label", "Collapse all");
+		} else {
+			this._collapseAll();
+			this._allCollapsed = true;
+			setIcon(this._collapseToggleBtn, "chevrons-up-down");
+			this._collapseToggleBtn.setAttribute("aria-label", "Expand all");
+		}
 	}
 
 	private _collapseAll(): void {

--- a/src/components/outlineWindow.ts
+++ b/src/components/outlineWindow.ts
@@ -1,5 +1,5 @@
 import DynamicOutlinePlugin, { WINDOW_ID } from "main";
-import { HeadingCache } from "obsidian";
+import { HeadingCache, setIcon } from "obsidian";
 import OutlineLiElement from "./outlineLiElement";
 import SearchContainer from "./searchContainer";
 import * as fuzzysort from "fuzzysort";
@@ -14,6 +14,7 @@ export default class OutlineWindow {
 	private _outline: Outline;
 	private _containerEl: HTMLDivElement;
 	private _latestHeadings: HeadingCache[] = [];
+	private _toolbarEl!: HTMLDivElement;
 	private _pinned = false;
 
 	constructor(plugin: DynamicOutlinePlugin, outline: Outline) {
@@ -157,6 +158,8 @@ export default class OutlineWindow {
 				isCollapsingPossibleGlobally = true;
 			}
 		}
+
+		this._toolbarEl.classList.toggle("hidden", !isCollapsingPossibleGlobally);
 
 		const minLevel: number = Math.min(...headings.map((h) => h.level));
 		const topLevelCount: number = headings.filter(
@@ -393,6 +396,26 @@ export default class OutlineWindow {
 			},
 		});
 
+		this._toolbarEl = createEl("div", {
+			cls: "dynamic-outline-toolbar hidden",
+		});
+
+		const collapseAllBtn = this._toolbarEl.createDiv({
+			cls: "clickable-icon",
+			attr: { "aria-label": "Collapse all" },
+		});
+		setIcon(collapseAllBtn, "chevrons-down-up");
+		collapseAllBtn.addEventListener("click", () => this._collapseAll());
+
+		const expandAllBtn = this._toolbarEl.createDiv({
+			cls: "clickable-icon",
+			attr: { "aria-label": "Expand all" },
+		});
+		setIcon(expandAllBtn, "chevrons-up-down");
+		expandAllBtn.addEventListener("click", () => this._expandAll());
+
+		mainElement.appendChild(this._toolbarEl);
+
 		const searchContainer: SearchContainer = new SearchContainer(
 			this._plugin
 		);
@@ -405,6 +428,35 @@ export default class OutlineWindow {
 		mainElement.appendChild(contentElement);
 
 		return mainElement;
+	}
+
+	private _collapseAll(): void {
+		const ul = this._containerEl.querySelector("ul");
+		if (!ul) return;
+		const items = Array.from(ul.querySelectorAll("li")) as HTMLLIElement[];
+		if (items.length === 0) return;
+
+		const isSingleTopLevel = this._containerEl.classList.contains("has-single-top-level");
+		const minLevel = Math.min(...items.map(li => parseInt(li.dataset.level || "0")));
+		const rootLevel = isSingleTopLevel ? minLevel + 1 : minLevel;
+
+		items.forEach((li) => {
+			const level = parseInt(li.dataset.level || "0");
+			if (li.classList.contains("has-children") && !li.classList.contains("is-single-top-level")) {
+				li.classList.add("collapsed");
+			}
+			if (level > rootLevel) {
+				li.classList.add("hidden-by-collapse");
+			}
+		});
+	}
+
+	private _expandAll(): void {
+		const ul = this._containerEl.querySelector("ul");
+		if (!ul) return;
+		ul.querySelectorAll("li").forEach((li) => {
+			li.classList.remove("collapsed", "hidden-by-collapse");
+		});
 	}
 
 	private _getVisibleLiItems(): Array<HTMLElement> {

--- a/styles.css
+++ b/styles.css
@@ -840,7 +840,31 @@ button.dynamic-outline-reload[disabled] {
 	display: block;
 }
 
-/* 
+/*
+ * Dynamic Outline Toolbar
+ */
+
+.dynamic-outline-toolbar {
+	display: flex;
+	justify-content: center;
+	gap: 2px;
+	padding: 4px 15px 0;
+}
+
+.dynamic-outline-toolbar.hidden {
+	display: none;
+}
+
+#dynamic-outline.is-searching .dynamic-outline-toolbar {
+	display: none;
+}
+
+.dynamic-outline-toolbar .clickable-icon svg {
+	width: 16px;
+	height: 16px;
+}
+
+/*
  * Dynamic Outline Content Container
  */
 


### PR DESCRIPTION
## Summary

- Adds a minimalistic toolbar with "Collapse all" and "Expand all" icon buttons at the top of the outline window, mimicking the default Obsidian file browser UX
- Uses Obsidian's native `clickable-icon` class and `setIcon` API (`chevrons-down-up` / `chevrons-up-down`)
- Toolbar auto-hides when collapsing isn't possible (single heading level or collapsing disabled) and during search

## Details

**Collapse all** collapses every parent heading, showing only top-level items. Correctly handles the single-top-level case (lone H1 stays expanded, its direct children become the visible roots).

**Expand all** removes all collapsed state, restoring full visibility.

Only 2 files changed, +78 lines:
- `src/components/outlineWindow.ts` - toolbar creation, collapse/expand logic, visibility toggle in `update()`
- `styles.css` - toolbar layout (centered flex row, 16px icons)

## Test plan

- [ ] Open a note with multiple heading levels (e.g. H1 > H2 > H3) - toolbar should appear
- [ ] Click collapse all - only top-level headings remain visible
- [ ] Click expand all - all headings reappear
- [ ] Open a note with a single heading level (all H2s) - toolbar should be hidden
- [ ] Type in search field - toolbar hides during search
- [ ] Test with "Disable heading collapsing" setting enabled - toolbar should be hidden
- [ ] Test with a single top-level heading (one H1 + nested H2s/H3s) - collapse all keeps H1 and H2s visible, hides H3+

🤖 Generated with [Claude Code](https://claude.com/claude-code)